### PR TITLE
Update plugin to selection-based config

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -18,7 +18,7 @@ test('converts all event names to camelCase', async () => {
         createEvent({ event: option })
     )
     
-    const eventsOutput = await processEventBatch([...events], { global: { defaultTransformationIndex: 0 } })
+    const eventsOutput = await processEventBatch([...events], { config: { defaultNamingConvention: 'camelCase' } })
     for (const event of eventsOutput) {
         expect(event).toEqual( createEvent({ event: 'helloThereWorld' }))
     }
@@ -32,7 +32,7 @@ test('converts all event names to PascalCase', async () => {
         createEvent({ event: option })
     )
     
-    const eventsOutput = await processEventBatch([...events], { global: { defaultTransformationIndex: 1 } })
+    const eventsOutput = await processEventBatch([...events], { config: { defaultNamingConvention: 'PascalCase' } })
     for (const event of eventsOutput) {
         expect(event).toEqual( createEvent({ event: 'HelloThereWorld' }))
     }
@@ -46,7 +46,7 @@ test('converts all event names to snake_case', async () => {
         createEvent({ event: option })
     )
     
-    const eventsOutput = await processEventBatch([...events], { global: { defaultTransformationIndex: 2 } })
+    const eventsOutput = await processEventBatch([...events], { config: { defaultNamingConvention: 'snake_case' } })
     for (const event of eventsOutput) {
         expect(event).toEqual( createEvent({ event: 'hello_there_world' }))
     }
@@ -61,7 +61,7 @@ test('converts all event names to kebab-case', async () => {
         createEvent({ event: option })
     )
     
-    const eventsOutput = await processEventBatch([...events], { global: { defaultTransformationIndex: 3 } })
+    const eventsOutput = await processEventBatch([...events], { config: { defaultNamingConvention: 'kebab-case' } })
     for (const event of eventsOutput) {
         expect(event).toEqual( createEvent({ event: 'hello-there-world' }))
     }
@@ -76,7 +76,7 @@ test('converts all event names to spaces in between', async () => {
         createEvent({ event: option })
     )
     
-    const eventsOutput = await processEventBatch([...events], { global: { defaultTransformationIndex: 4 } })
+    const eventsOutput = await processEventBatch([...events], { config: { defaultNamingConvention: 'spaces in between' } })
     for (const event of eventsOutput) {
         expect(event).toEqual( createEvent({ event: 'hello there world' }))
     }

--- a/index.js
+++ b/index.js
@@ -26,20 +26,18 @@ const transformations = [
     },
 ] 
 
-
-function setupPlugin({ config, global }) {
-    const selectedTransformationIndex = Number(config.defaultNamingConventionIndex)
-    if (Number.isNaN(selectedTransformationIndex) || selectedTransformationIndex > transformations.length) {
-        throw new Error('Invalid naming convention selection.')
-    }
-
-    global.defaultTransformationIndex = selectedTransformationIndex - 1
-
+const configSelectionMap = {
+    "camelCase": 0,
+    "PascalCase": 1,
+    "snake_case": 2,
+    "kebab-case": 3,
+    "spaces in between": 4
 }
 
-async function processEventBatch(events, { global }) {
+
+async function processEventBatch(events, { config }) {
     for (let event of events) {
-        event.event = standardizeName(event.event, transformations[global.defaultTransformationIndex])
+        event.event = standardizeName(event.event, transformations[configSelectionMap[config.defaultNamingConvention]])
     }
     return events
 }
@@ -68,6 +66,5 @@ const standardizeName = (name, desiredPattern) => {
 }
 
 module.exports = {
-    setupPlugin,
     processEventBatch
 }

--- a/plugin.json
+++ b/plugin.json
@@ -8,8 +8,8 @@
             "key": "defaultNamingConvention",
             "hint": "camelCase = 1, PascalCase = 2, snake_case = 3, kebab-case = 4, spaces in between = 5",
             "name": "Select your default naming pattern by typing the corresponding number",
-            "type": "selection",
-            "options": [
+            "type": "choice",
+            "choices": [
                 "camelCase",
                 "PascalCase",
                 "snake_case",

--- a/plugin.json
+++ b/plugin.json
@@ -5,10 +5,17 @@
     "main": "index.js",
     "config": [
         {
-            "key": "defaultNamingConventionIndex",
+            "key": "defaultNamingConvention",
             "hint": "camelCase = 1, PascalCase = 2, snake_case = 3, kebab-case = 4, spaces in between = 5",
             "name": "Select your default naming pattern by typing the corresponding number",
-            "type": "string",
+            "type": "selection",
+            "options": [
+                "camelCase",
+                "PascalCase",
+                "snake_case",
+                "kebab-case",
+                "spaces in between"
+            ],
             "order": 1,
             "default": "3",
             "required": true


### PR DESCRIPTION
Depends on:

- https://github.com/PostHog/plugin-scaffold/pull/7
- https://github.com/PostHog/posthog/pull/3229

Also raises the point that we could have the options array be objects rather than strings, so one can specify the display value for the user and the corresponding value for the config. 

Like, instead of having:

```
<Select.Option value={option} >
    {option}
</Select.Option>
```

We could have:

```
<Select.Option value={option.value} >
    {option.name}
</Select.Option>
```

But I'll leave this up for discussion.