### PR TITLE
prevent the app to run on PostHog default properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@ const configSelectionMap = {
 
 async function processEventBatch(events, { config }) {
     for (let event of events) {
-        event.event = standardizeName(event.event, transformations[configSelectionMap[config.defaultNamingConvention]])
+        if (!event.event.startsWith("$")) {
+            event.event = standardizeName(event.event, transformations[configSelectionMap[config.defaultNamingConvention]])
+        }
     }
     return events
 }


### PR DESCRIPTION
this plugin in the `spaces in between` option will break the `$create_alias` event
https://posthoghelp.zendesk.com/agent/tickets/15469