### PR TITLE
Skip survey events from being taxonomized

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,16 @@ const configSelectionMap = {
     "spaces in between": 4
 }
 
+const skippedPostHogEvents = [
+    'survey shown',
+    'survey sent',
+    'survey dismissed',
+]
+
 
 async function processEventBatch(events, { config }) {
     for (let event of events) {
-        if (!event.event.startsWith("$")) {
+        if (!event.event.startsWith("$") && !skippedPostHogEvents.includes(event.event)) {
             event.event = standardizeName(event.event, transformations[configSelectionMap[config.defaultNamingConvention]])
         }
     }


### PR DESCRIPTION
I'm seeing that events sent by the Survey extension in PostHog also get changed if the Taxonomy plugin is enabled and set to Pascal Case. This PR adds an exclusion list to the transformation that includes events sent by PostHog surveys.